### PR TITLE
Fix dependencies between Dash components

### DIFF
--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -12,11 +12,16 @@ MutableSequence = patch_collections_abc("MutableSequence")
 rd = random.Random(0)
 
 
+class OrderedSet(collections.OrderedDict):
+    def add(self, item):
+        self[item] = None
+
+
 # pylint: disable=no-init,too-few-public-methods
 class ComponentRegistry:
     """Holds a registry of the namespaces used by components."""
 
-    registry = set()
+    registry = OrderedSet()
     children_props = collections.defaultdict(dict)
 
     @classmethod


### PR DESCRIPTION
I have a `dash-component1` that depends on `react-lib1`. I also have `dash-component2`, which depends on `react-lib1` and `dash-component1`. `dash-component2` is a plugin to `dash-component1`.
Since `ComponentRegistry.registry` is an unordered set, the Dash components added to it may not be in the order in which they were added to it.
I need to load scripts (dash components) in the order in which they were imported.
I suggest a small change in `dash/development/base_component.py`
```python
...

class OrderedSet(collections.OrderedDict):
    def add(self, item):
        self[item] = None


class ComponentRegistry:
    registry = OrderedSet()  # set() <<
...
```